### PR TITLE
Add getAll() to env

### DIFF
--- a/env/README.md
+++ b/env/README.md
@@ -10,7 +10,7 @@ const env = require('@brocan/env').ensure([
     'PORT'
 ]);
 
-const port = env.get('PORT');
+const [ port, host ] = env.getAll([ 'PORT', 'HOST' ]);
 
 // will return localhost if HOST is unset
 const host = env.getOrDefault('HOST', 'localhost');
@@ -27,6 +27,10 @@ Returns the env instance if all properties are set.
 ### `get(property: string): string`
 
 Provides the same functionality as `config.get()`.
+
+### `getAll(...properties: string): Array<string>`
+
+Returns property values for multiple properties.
 
 ### `getOrDefault(property: string, value: any): any`
 

--- a/env/package.json
+++ b/env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brocan/env",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A simple wrapper around node-config which provides a way to ensure the presence of required properties.",
   "main": "src/index.js",
   "repository": {

--- a/env/src/index.js
+++ b/env/src/index.js
@@ -21,6 +21,9 @@ const env = {
     get(property) {
         return this.hasEnv(property) ? this.getEnv(property) : this.deps.config.get(property);
     },
+    getAll(...properties) {
+        return properties.map(property => this.get(property));
+    },
     getOrDefault(property, value) {
         return this.has(property) ? this.get(property) : value;
     },


### PR DESCRIPTION
Added the `getAll()` function to env which provides a batch property-querying functionality.