### PR TITLE
Deprecate env

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ The intended features of Brocan are the following:
 ### Libraries
 
   * [brocanfile](brocanfile) - Node brocanfile parser and validator.
-  * [env](env) - Environment configuration libary for Node based on [node-config](https://github.com/lorenwest/node-config).
+  * [env](env) - **[DEPRECATED - Use convict instead]** Environment configuration libary for Node based on [node-config](https://github.com/lorenwest/node-config).
   * [sequ](sequ) - Node promise queue which ensures the sequential execution of promises.

--- a/bolt/README.md
+++ b/bolt/README.md
@@ -20,7 +20,6 @@ bolt
 ## Project Dependencies
 
   * brocanfile
-  * env
   * sequ
 
 ## Expected environment variables

--- a/bolt/README.md
+++ b/bolt/README.md
@@ -22,15 +22,9 @@ bolt
   * brocanfile
   * sequ
 
-## Expected environment variables
+## Expected configuration and environment variables
 
-Instead of relying on command line parameters, Bolt expects some environment variables to be present when being run:
-
-  * `BOLT_RUNNER_BROCANFILE_PATH` - Relative path to the brocanfile to be executed.
-  * `BOLT_RUNNER_BUILD_ID` - An arbitrary identifier of the current build.
-  * `BOLT_RUNNER_REPORTER_HOST` - The host Bolt will report to.
-
-These can also be set in configuration files in a `node-config` compatible way.
+Please see the schema in [src/config.js](src/config.js) for documentation and default values.
 
 ## Build execution
 

--- a/bolt/package-lock.json
+++ b/bolt/package-lock.json
@@ -23,6 +23,11 @@
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
+    "camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+    },
     "color": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/color/-/color-0.8.0.tgz",
@@ -69,6 +74,20 @@
         "text-hex": "0.0.0"
       }
     },
+    "convict": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/convict/-/convict-4.0.1.tgz",
+      "integrity": "sha1-3yhunfaNik43icCfkvSdK6e51Z4=",
+      "requires": {
+        "depd": "1.1.1",
+        "json5": "0.5.1",
+        "lodash.clonedeep": "4.5.0",
+        "moment": "2.18.1",
+        "validator": "7.2.0",
+        "varify": "0.2.0",
+        "yargs-parser": "7.0.0"
+      }
+    },
     "date-fns": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
@@ -81,6 +100,11 @@
       "requires": {
         "mimic-response": "1.0.0"
       }
+    },
+    "depd": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
     },
     "diagnostics": {
       "version": "1.1.0",
@@ -109,6 +133,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.3.tgz",
       "integrity": "sha1-uGwWQb5WECZ9UG8YBx6nbXBwl8s="
+    },
+    "esprima": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz",
+      "integrity": "sha1-U88kes2ncxPlUcOqLnM0LT+099k=",
+      "optional": true
     },
     "get-stream": {
       "version": "3.0.0",
@@ -211,6 +241,11 @@
         "topo": "3.0.0"
       }
     },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+    },
     "kuler": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
@@ -218,6 +253,11 @@
       "requires": {
         "colornames": "0.0.2"
       }
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "logform": {
       "version": "1.2.1",
@@ -237,6 +277,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
       "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
+    },
+    "moment": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
     },
     "one-time": {
       "version": "0.0.4",
@@ -271,6 +316,15 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
       "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
     },
+    "redeyed": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
+      "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
+      "optional": true,
+      "requires": {
+        "esprima": "3.0.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -285,6 +339,12 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
       "integrity": "sha1-V4+8haapJjbkLdF7QdAhjM6esrM="
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "optional": true
     },
     "timed-out": {
       "version": "4.0.1",
@@ -317,6 +377,21 @@
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
     },
+    "validator": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-7.2.0.tgz",
+      "integrity": "sha512-c8NGTUYeBEcUIGeMppmNVKHE7wwfm3mYbNZxV+c5mlv9fDHI7Ad3p07qfNrn/CvpdkK2k61fOLRO2sTEhgQXmg=="
+    },
+    "varify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/varify/-/varify-0.2.0.tgz",
+      "integrity": "sha1-GR2p/p3EzWjQ0USY1OKpEP9OZRY=",
+      "optional": true,
+      "requires": {
+        "redeyed": "1.0.1",
+        "through": "2.3.8"
+      }
+    },
     "winston": {
       "version": "3.0.0-rc1",
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.0.0-rc1.tgz",
@@ -336,6 +411,14 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-3.0.1.tgz",
       "integrity": "sha1-gAixXu9WYMT7P6CU1YzL0IUoxY0="
+    },
+    "yargs-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+      "requires": {
+        "camelcase": "4.1.0"
+      }
     }
   }
 }

--- a/bolt/package-lock.json
+++ b/bolt/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@brocan/bolt",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@brocan/brocanfile": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@brocan/brocanfile/-/brocanfile-1.0.0.tgz",
-      "integrity": "sha512-cvb6Rq4fQ7Odlix98rLMwKme+j8i+n9JhhZ2sfQDYzNAGh8k6CXD+KV8hcqxeqUlXhd2LHf+Hf21tFv50NcvLQ=="
-    },
-    "@brocan/env": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@brocan/env/-/env-1.2.0.tgz",
-      "integrity": "sha512-nlaDqb1nhs1TeGPhBgpfX7Im2bEjicMSnYOvSXucBNPrmN0ye1gesxbgQAaSnoVaoiv1uWc/1MQ+cVC5LNGEXQ=="
+      "integrity": "sha512-cvb6Rq4fQ7Odlix98rLMwKme+j8i+n9JhhZ2sfQDYzNAGh8k6CXD+KV8hcqxeqUlXhd2LHf+Hf21tFv50NcvLQ==",
+      "requires": {
+        "hjson": "3.1.0",
+        "joi": "13.0.1"
+      }
     },
     "@brocan/sequ": {
       "version": "1.0.0",
@@ -26,7 +26,11 @@
     "color": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/color/-/color-0.8.0.tgz",
-      "integrity": "sha1-iQwHw/1OZJU3Y4kRz2keVFi2/KU="
+      "integrity": "sha1-iQwHw/1OZJU3Y4kRz2keVFi2/KU=",
+      "requires": {
+        "color-convert": "0.5.3",
+        "color-string": "0.3.0"
+      }
     },
     "color-convert": {
       "version": "0.5.3",
@@ -41,7 +45,10 @@
     "color-string": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE="
+      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+      "requires": {
+        "color-name": "1.1.3"
+      }
     },
     "colornames": {
       "version": "0.0.2",
@@ -56,12 +63,11 @@
     "colorspace": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz",
-      "integrity": "sha1-yZx5btMRKLmHalLh7l7gOkpxl0k="
-    },
-    "config": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/config/-/config-1.27.0.tgz",
-      "integrity": "sha1-OrMNAID/dvQHwvR6wTJq39kIr18="
+      "integrity": "sha1-yZx5btMRKLmHalLh7l7gOkpxl0k=",
+      "requires": {
+        "color": "0.8.0",
+        "text-hex": "0.0.0"
+      }
     },
     "date-fns": {
       "version": "1.29.0",
@@ -71,12 +77,20 @@
     "decompress-response": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M="
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "1.0.0"
+      }
     },
     "diagnostics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.0.tgz",
-      "integrity": "sha1-4QkJALSVI+hSe+IPCBJ1IF8q42o="
+      "integrity": "sha1-4QkJALSVI+hSe+IPCBJ1IF8q42o=",
+      "requires": {
+        "colorspace": "1.0.1",
+        "enabled": "1.0.2",
+        "kuler": "0.0.0"
+      }
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -86,7 +100,10 @@
     "enabled": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
-      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M="
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "requires": {
+        "env-variable": "0.0.3"
+      }
     },
     "env-variable": {
       "version": "0.0.3",
@@ -101,7 +118,23 @@
     "got": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-      "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw=="
+      "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+      "requires": {
+        "decompress-response": "3.3.0",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-plain-obj": "1.1.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "isurl": "1.0.0",
+        "lowercase-keys": "1.0.0",
+        "p-cancelable": "0.3.0",
+        "p-timeout": "1.2.0",
+        "safe-buffer": "5.1.1",
+        "timed-out": "4.0.1",
+        "url-parse-lax": "1.0.0",
+        "url-to-options": "1.0.1"
+      }
     },
     "has-symbol-support-x": {
       "version": "1.4.1",
@@ -111,7 +144,10 @@
     "has-to-string-tag-x": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw=="
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "requires": {
+        "has-symbol-support-x": "1.4.1"
+      }
     },
     "hjson": {
       "version": "3.1.0",
@@ -119,9 +155,9 @@
       "integrity": "sha512-32Xt9W+25uH3/nKUkAGTrwRj0pbibWUI25pUzM13QPSRMRAHSoXgjQ1NS/tscpZ53h9CwrSy7woAlzJDCydWig=="
     },
     "hoek": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.1.tgz",
-      "integrity": "sha512-sZ2Et6jQxNCSShCUlPqzLNVD5bjWQxrCE6Bi4pgxcWaqIGk6dwdWszcJTn1qwrQLRwflxTaxfDX+QU3kioDuvw=="
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.2.tgz",
+      "integrity": "sha512-NA10UYP9ufCtY2qYGkZktcQXwVyYK4zK0gkaFSB96xhtlo6V8tKXdQgx8eHolQTRemaW0uLn8BhjhwqrOU+QLQ=="
     },
     "is-object": {
       "version": "1.0.1",
@@ -146,7 +182,10 @@
     "isemail": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.0.0.tgz",
-      "integrity": "sha512-rz0ng/c+fX+zACpLgDB8fnUQ845WSU06f4hlhk4K8TJxmR6f5hyvitu9a9JdMD7aq/P4E0XdG1uaab2OiXgHlA=="
+      "integrity": "sha512-rz0ng/c+fX+zACpLgDB8fnUQ845WSU06f4hlhk4K8TJxmR6f5hyvitu9a9JdMD7aq/P4E0XdG1uaab2OiXgHlA==",
+      "requires": {
+        "punycode": "2.1.0"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -156,27 +195,38 @@
     "isurl": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
-      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w=="
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "requires": {
+        "has-to-string-tag-x": "1.4.1",
+        "is-object": "1.0.1"
+      }
     },
     "joi": {
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/joi/-/joi-13.0.1.tgz",
-      "integrity": "sha512-ChTMfmbIg5yrN9pUdeaLL8vzylMQhUteXiXa1MWINsMUs3jTQ8I87lUZwR5GdfCLJlpK04U7UgrxgmU8Zp7PhQ=="
-    },
-    "json5": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-      "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
+      "integrity": "sha512-ChTMfmbIg5yrN9pUdeaLL8vzylMQhUteXiXa1MWINsMUs3jTQ8I87lUZwR5GdfCLJlpK04U7UgrxgmU8Zp7PhQ==",
+      "requires": {
+        "hoek": "5.0.2",
+        "isemail": "3.0.0",
+        "topo": "3.0.0"
+      }
     },
     "kuler": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
-      "integrity": "sha1-tmu0a5NOVQ9Z2BiEjgq7pPf1VTw="
+      "integrity": "sha1-tmu0a5NOVQ9Z2BiEjgq7pPf1VTw=",
+      "requires": {
+        "colornames": "0.0.2"
+      }
     },
     "logform": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/logform/-/logform-1.2.1.tgz",
-      "integrity": "sha1-5wfvez86nxbCSK5X8dAVB0/Ga/U="
+      "integrity": "sha1-5wfvez86nxbCSK5X8dAVB0/Ga/U=",
+      "requires": {
+        "colors": "1.1.2",
+        "date-fns": "1.29.0"
+      }
     },
     "lowercase-keys": {
       "version": "1.0.0",
@@ -193,11 +243,6 @@
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
       "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4="
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
     "p-cancelable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
@@ -211,7 +256,10 @@
     "p-timeout": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.0.tgz",
-      "integrity": "sha1-mCD5lDTFgXhotPNICe5SkWYNW2w="
+      "integrity": "sha1-mCD5lDTFgXhotPNICe5SkWYNW2w=",
+      "requires": {
+        "p-finally": "1.0.0"
+      }
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -246,7 +294,10 @@
     "topo": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
-      "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw=="
+      "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+      "requires": {
+        "hoek": "5.0.2"
+      }
     },
     "triple-beam": {
       "version": "1.1.0",
@@ -256,7 +307,10 @@
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM="
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "requires": {
+        "prepend-http": "1.0.4"
+      }
     },
     "url-to-options": {
       "version": "1.0.1",
@@ -266,7 +320,17 @@
     "winston": {
       "version": "3.0.0-rc1",
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.0.0-rc1.tgz",
-      "integrity": "sha512-aNtKirnK2UEe5v56SK0TIEr5ylyYdXyjAaIJXZTk21UlNx7FQclTkVU2T1ZzMtdDM+Rk2b7vrI/e/4n8U84XaQ=="
+      "integrity": "sha512-aNtKirnK2UEe5v56SK0TIEr5ylyYdXyjAaIJXZTk21UlNx7FQclTkVU2T1ZzMtdDM+Rk2b7vrI/e/4n8U84XaQ==",
+      "requires": {
+        "async": "1.5.2",
+        "diagnostics": "1.1.0",
+        "isstream": "0.1.2",
+        "logform": "1.2.1",
+        "one-time": "0.0.4",
+        "stack-trace": "0.0.10",
+        "triple-beam": "1.1.0",
+        "winston-transport": "3.0.1"
+      }
     },
     "winston-transport": {
       "version": "3.0.1",

--- a/bolt/package.json
+++ b/bolt/package.json
@@ -17,7 +17,6 @@
   "license": "MIT",
   "dependencies": {
     "@brocan/brocanfile": "^1.0.0",
-    "@brocan/env": "^1.2.0",
     "@brocan/sequ": "^1.0.0",
     "got": "^7.1.0",
     "winston": "^3.0.0-rc1"

--- a/bolt/package.json
+++ b/bolt/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@brocan/brocanfile": "^1.0.0",
     "@brocan/sequ": "^1.0.0",
+    "convict": "^4.0.1",
     "got": "^7.1.0",
     "winston": "^3.0.0-rc1"
   }

--- a/bolt/src/config.js
+++ b/bolt/src/config.js
@@ -1,0 +1,42 @@
+const path = require('path');
+const convict = require('convict');
+const logger = require('./logger');
+
+
+const config = convict({
+    env: {
+        doc: 'The application environment.',
+        format: ['production', 'development', 'test'],
+        default: 'production',
+        env: 'NODE_ENV'
+    },
+    brocanFilePath: {
+        doc: 'Relative path to the brocanfile to be executed.',
+        format: String,
+        default: 'brocan.hjson',
+        env: 'BOLT_RUNNER_BROCANFILE_PATH'
+    },
+    buildId: {
+        doc: 'An arbitrary identifier of the current build.',
+        format: String,
+        default: null,
+        env: 'BOLT_RUNNER_BUILD_ID'
+    },
+    reporterHost: {
+        doc: 'The host Bolt will report to.',
+        format: String,
+        default: 'localhost:3000',
+        env: 'BOLT_RUNNER_REPORTER_HOST'
+    }
+});
+
+
+logger.debug('Loading configuration with schema');
+logger.debug(config.getSchema());
+
+logger.info('Loaded configuration');
+logger.debug(config.toString());
+
+config.validate({ allowed: 'strict' });
+
+module.exports = config;

--- a/bolt/src/index.js
+++ b/bolt/src/index.js
@@ -1,10 +1,5 @@
 #!/usr/bin/env node
-
-const env = require('@brocan/env').ensure([
-    'BOLT_RUNNER_BROCANFILE_PATH',
-    'BOLT_RUNNER_BUILD_ID',
-    'BOLT_RUNNER_REPORTER_HOST'
-]);
+const config = require('./config');
 
 const Sequ = require('@brocan/sequ');
 const brocanfile = require('@brocan/brocanfile');
@@ -13,11 +8,11 @@ const logger = require('./logger');
 const Reporter = require('./reporter');
 const Executor = require('./executor');
 
-const [ brocanFilePath, buildId, reporterHost ] = env.getAll(
-    'BOLT_RUNNER_BROCANFILE_PATH',
-    'BOLT_RUNNER_BUILD_ID',
-    'BOLT_RUNNER_REPORTER_HOST'
-);
+const [ brocanFilePath, buildId, reporterHost ] = [
+    'brocanFilePath',
+    'buildId',
+    'reporterHost'
+].map(prop => config.get(prop));
 
 const reporter = Object.create(Reporter);
 reporter.Reporter(reporterHost, buildId, Sequ());

--- a/bond/README.md
+++ b/bond/README.md
@@ -5,7 +5,6 @@ Bond is the build agent of Brocan CI.
 ## Project Dependencies
 
   * brocanfile
-  * env
 
 ## Environment Dependencies
 

--- a/bond/src/config.js
+++ b/bond/src/config.js
@@ -7,7 +7,7 @@ const config = convict({
     env: {
         doc: 'The application environment.',
         format: ['production', 'development', 'test'],
-        default: 'development',
+        default: 'production',
         env: 'NODE_ENV'
     },
     collector: {

--- a/env/README.md
+++ b/env/README.md
@@ -1,4 +1,6 @@
-# env
+# [DEPRECATED] env
+
+**Instead of using env, the usage of convict is recommended!**
 
 A simple wrapper around `node-config` which provides a way to ensure the presence of required properties.
 


### PR DESCRIPTION
As the convict package is a much better solution than the node-config based env, marked env as deprecated and replaced its usages.